### PR TITLE
chore: add ch 03 exercises functionality

### DIFF
--- a/src/main/java/com/streamwork/ch03/api/FieldsGrouping.java
+++ b/src/main/java/com/streamwork/ch03/api/FieldsGrouping.java
@@ -19,10 +19,20 @@ public class FieldsGrouping implements GroupingStrategy, Serializable {
     return event.getData();
   }
 
+  //// Added by me - group by length of event string
+  //protected Integer getKey(Event event) {
+  //  return ((String) event.getData()).length();
+  //}
+
+  //// Added by me - group by first character of event string
+  //protected Character getKey(Event event) {
+  //  return ((String) event.getData()).charAt(0);
+  //}
+
   /**
    * Get target instance id from an event and component parallelism.
    * @param event The event object to route to the component.
-   * @param The parallelism of the component.
+   * @param parallelism The parallelism of the component.
    * @return The integer key of this event.
    */
   @Override


### PR DESCRIPTION
# Description

Add functionality asked for in Chapter 3 exercise questions on p. 80 of the print book.

### Exercises

1. Why is parallelization important?
2. Can you think of any other grouping strategy? If you can think of one, can you implement it in Streamwork?
3. The field grouping in the example is using the hash of the string. Can you implement a different field grouping that uses the first character instead? What are the advantages and disadvantages of this new grouping strategy?